### PR TITLE
Rename this.open and this.close

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ You can override these:
 var stringify = Stringify()
 stringify.replacer = function () {}
 stringify.space = 2
+stringify.opener = '['
+stringify.seperator = ','
+stringify.closer = ']'
 ```
 
 [gitter-image]: https://badges.gitter.im/stream-utils/streaming-json-stringify.png

--- a/index.js
+++ b/index.js
@@ -31,9 +31,9 @@ function Stringify(options) {
   var close = options && options.close ? options.close : '\n]\n'
 
   // Array Deliminators
-  this.open = new Buffer(open, 'utf8')
+  this.opener = new Buffer(open, 'utf8')
   this.seperator = new Buffer(seperator, 'utf8')
-  this.close = new Buffer(close, 'utf8')
+  this.closer = new Buffer(close, 'utf8')
 }
 
 // Flags
@@ -47,7 +47,7 @@ Stringify.prototype._transform = function (doc, enc, cb) {
   if (this.started) {
     this.push(this.seperator)
   } else {
-    this.push(this.open)
+    this.push(this.opener)
     this.started = true
   }
 
@@ -58,8 +58,8 @@ Stringify.prototype._transform = function (doc, enc, cb) {
 }
 
 Stringify.prototype._flush = function (cb) {
-  if (!this.started) this.push(this.open)
-  this.push(this.close)
+  if (!this.started) this.push(this.opener)
+  this.push(this.closer)
   this.push(null)
   cb()
 }

--- a/index.js
+++ b/index.js
@@ -26,14 +26,14 @@ function Stringify(options) {
   this._writableState.objectMode = true
 
   // Array Deliminator defaults
-  var open = options && options.open ? options.open : '[\n'
+  var opener = options && options.opener ? options.opener : '[\n'
   var seperator = options && options.seperator ? options.seperator : '\n,\n'
-  var close = options && options.close ? options.close : '\n]\n'
+  var closer = options && options.closer ? options.closer : '\n]\n'
 
   // Array Deliminators
-  this.opener = new Buffer(open, 'utf8')
+  this.opener = new Buffer(opener, 'utf8')
   this.seperator = new Buffer(seperator, 'utf8')
-  this.closer = new Buffer(close, 'utf8')
+  this.closer = new Buffer(closer, 'utf8')
 }
 
 // Flags

--- a/test/test.js
+++ b/test/test.js
@@ -161,7 +161,7 @@ describe('Streamify()', function () {
       objectMode: true
     })
 
-    var stringify = Stringify({open: "{\"test\": [\n", close: "\n]}\n"})
+    var stringify = Stringify({opener: "{\"test\": [\n", closer: "\n]}\n"})
 
     var obj = [{a: 1}]
 


### PR DESCRIPTION
When using Hapi (at least v8.8), they try calling `this.close()`. I’m not sure if this is an error with Hapi’s implementation or a conflict with the expected Streams API, but by renaming the options the error goes away.

Let me know if this seems OK to change, or if you don’t like the variable names I’ve chosen, I can replace them.