### PR TITLE
Allow custom stringifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ will yield something like
 * Documents are separated by `'\n,\n'`.
 * The stream is terminated with `'\n]\n'`.
 
+## Stringifier
+
+By default, [json-stringify-safe](https://www.npmjs.com/package/json-stringify-safe) is used to convert objects into strings. This can be configured with `options.stringifier`.
+
 ## API
 
 ### Stringify([options])
@@ -62,6 +66,7 @@ stringify.space = 2
 stringify.opener = '['
 stringify.seperator = ','
 stringify.closer = ']'
+stringify.stringifier = JSON.stringify
 ```
 
 [gitter-image]: https://badges.gitter.im/stream-utils/streaming-json-stringify.png

--- a/index.js
+++ b/index.js
@@ -25,15 +25,17 @@ function Stringify(options) {
   Transform.call(this, options || {})
   this._writableState.objectMode = true
 
-  // Array Deliminator defaults
+  // Array Deliminator and Stringifier defaults
   var opener = options && options.opener ? options.opener : '[\n'
   var seperator = options && options.seperator ? options.seperator : '\n,\n'
   var closer = options && options.closer ? options.closer : '\n]\n'
+  var stringifier = options && options.stringifier ? options.stringifier : stringify
 
-  // Array Deliminators
+  // Array Deliminators and Stringifier
   this.opener = new Buffer(opener, 'utf8')
   this.seperator = new Buffer(seperator, 'utf8')
   this.closer = new Buffer(closer, 'utf8')
+  this.stringifier = stringifier
 }
 
 // Flags
@@ -51,7 +53,7 @@ Stringify.prototype._transform = function (doc, enc, cb) {
     this.started = true
   }
 
-  doc = stringify(doc, this.replacer, this.space)
+  doc = this.stringifier(doc, this.replacer, this.space)
 
   this.push(new Buffer(doc, 'utf8'))
   cb()

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "repository": "stream-utils/streaming-json-stringify",
   "license": "MIT",
   "devDependencies": {
-    "mocha": "2",
+    "cat-stream": "*",
     "istanbul": "0",
-    "cat-stream": "*"
+    "mocha": "2",
+    "sinon": "^1.17.2"
   },
   "scripts": {
     "test": "mocha --reporter spec",

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,7 @@
 var PassThrough = require('readable-stream/passthrough')
 var assert = require('assert')
 var cat = require('cat-stream')
+var sinon = require('sinon');
 
 var Stringify = require('..')
 
@@ -190,6 +191,31 @@ describe('Streamify()', function () {
         assert.ifError(err)
         assert.equal(buf.toString('utf8'), "[\n1 , 2 , 3\n]\n")
         
+        done()
+      }))
+
+    stream.write(1)
+    stream.write(2)
+    stream.write(3)
+    stream.end()
+  })
+
+  it('should allow custom stringifiers', function(done) {
+    var stream = new PassThrough({
+      objectMode: true
+    })
+
+    var stringifier = sinon.spy(JSON.stringify);
+
+    var stringify = Stringify({stringifier: stringifier})
+
+    stream
+      .pipe(stringify)
+      .pipe(cat(function (err, buf) {
+        assert.ifError(err)
+        assert.ok(stringifier.called)
+        assert.equal(buf.toString('utf8'), "[\n1\n,\n2\n,\n3\n]\n")
+
         done()
       }))
 


### PR DESCRIPTION
For our use, `json-stringify-safe` was too slow. This adds an option to specify a custom stringifier. Any feedback is appreciated.